### PR TITLE
Adding ads options to demo page

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Red Bee Media Ltd <https://www.redbeemedia.com/>
+#
+# SPDX-License-Identifier: MIT
+
+nodejs 20.14.0

--- a/apps/demo/src/index.ts
+++ b/apps/demo/src/index.ts
@@ -226,7 +226,7 @@ function getPlayerOptions(): IRedBeePlayerOptions {
 
 export function getLoadOptions(): ILoadOptions {
   const data = Object.fromEntries(getFilteredFormEntries());
-  const { source, startTime, start, end } = data;
+  const { source, startTime, start, end, domain, pageUrl, consent, ssaiCustomParams } = data;
 
   return {
     source,
@@ -237,6 +237,14 @@ export function getLoadOptions(): ILoadOptions {
         ...(end && { end }),
       },
     }),
+    ...((domain || pageUrl || consent || ssaiCustomParams) && {
+      ads: {
+        ...(domain && { domain }),
+        ...(pageUrl && { pageUrl }),
+        ...(consent && { consent }),
+        ...(ssaiCustomParams && Object.fromEntries((new URLSearchParams(ssaiCustomParams)).entries()))
+      }
+    })
   };
 }
 

--- a/apps/demo/src/template.html
+++ b/apps/demo/src/template.html
@@ -192,6 +192,37 @@ SPDX-License-Identifier: MIT
               </div>
             </section>
           </fieldset>
+          <fieldset id="options">
+            <legend>Ad options</legend>
+            <section class="m2">
+              <input
+                name="domain"
+                type="text"
+                placeholder="SSAI domain"
+                style="flex: 1 1 100px"
+              />
+              <input
+                name="pageUrl"
+                type="text"
+                placeholder="SSAI pageUrl"
+                style="flex: 1 1 300px"
+              />
+              <input
+                name="consent"
+                type="text"
+                placeholder="SSAI TCF consent string"
+                style="flex: 1 1 400px"
+              />
+            </section>
+            <section class="m2">
+              <input
+                name="ssaiCustomParams"
+                type="text"
+                placeholder="SSAI custom parameters"
+                style="flex: 1 1 400px"
+              />
+            </section>
+          </fieldset>
           <div id="video-buttons">
             <button id="load-button" type="submit" class="pure-button" data-variant="default">
               Load

--- a/apps/demo/webpack.config.mjs
+++ b/apps/demo/webpack.config.mjs
@@ -41,7 +41,7 @@ export default {
       template: "./src/template.html",
     }),
     new CopyPlugin({
-      patterns: [{ from: "src/static", to: "static" }],
+      patterns: [{ from: "src/static", to: "static", globOptions: { ignore: ['**/*.license'] } }],
     }),
     new webpack.DefinePlugin({
       "process.env.npm_package_version": JSON.stringify(

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "root",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -56,7 +56,7 @@
     },
     "apps/demo": {
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/javascript-player": "^1.6.0",
         "@ericssonbroadcastservices/js-player-core": "^1.6.0",
@@ -78,7 +78,7 @@
     "apps/web-component": {
       "name": "web-component-dev",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/js-player-web-component": "^1.6.0"
       }
@@ -23028,7 +23028,7 @@
     "packages/ad-monitor": {
       "name": "@ericssonbroadcastservices/js-player-ad-monitor",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/js-player-shared": "^1.6.0",
         "@ericssonbroadcastservices/rbm-ott-sdk": "0.7.1",
@@ -23044,7 +23044,7 @@
     "packages/analytics": {
       "name": "@ericssonbroadcastservices/js-player-analytics",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/js-player-ad-monitor": "^1.6.0",
         "@ericssonbroadcastservices/js-player-shared": "^1.6.0",
@@ -23069,7 +23069,7 @@
     "packages/cast-sender": {
       "name": "@ericssonbroadcastservices/js-player-cast-sender",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/js-player-shared": "^1.6.0"
       },
@@ -23080,7 +23080,7 @@
     "packages/core": {
       "name": "@ericssonbroadcastservices/js-player-core",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/js-player-ad-monitor": "^1.6.0",
         "@ericssonbroadcastservices/js-player-program-service": "^1.6.0",
@@ -23116,12 +23116,12 @@
     "packages/overlays": {
       "name": "@ericssonbroadcastservices/js-player-overlays",
       "version": "1.6.0",
-      "license": "Apache-2.0"
+      "license": "MIT"
     },
     "packages/player": {
       "name": "@ericssonbroadcastservices/javascript-player",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "devDependencies": {
         "@ericssonbroadcastservices/js-player-analytics": "^1.6.0",
         "@ericssonbroadcastservices/js-player-cast-sender": "^1.6.0",
@@ -23144,7 +23144,7 @@
     "packages/program-service": {
       "name": "@ericssonbroadcastservices/js-player-program-service",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/js-player-shared": "^1.6.0",
         "@ericssonbroadcastservices/rbm-ott-sdk": "0.7.1"
@@ -23159,7 +23159,7 @@
     "packages/shared": {
       "name": "@ericssonbroadcastservices/js-player-shared",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/rbm-ott-sdk": "0.7.1",
         "mitt": "3.0.0"
@@ -23174,7 +23174,7 @@
     "packages/skin": {
       "name": "@ericssonbroadcastservices/js-player-skin",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@ericssonbroadcastservices/js-player-shared": "^1.6.0",
         "classnames": "^2.2.6",
@@ -23200,7 +23200,7 @@
     "packages/sprite-vtt-parser": {
       "name": "@ericssonbroadcastservices/sprite-vtt-parser",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "url-toolkit": "^2.2.5",
         "webvtt-parser": "^2.1.2"
@@ -23209,7 +23209,7 @@
     "packages/web-component": {
       "name": "@ericssonbroadcastservices/js-player-web-component",
       "version": "1.6.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "devDependencies": {
         "@ericssonbroadcastservices/javascript-player": "^1.6.0",
         "@ericssonbroadcastservices/js-player-shared": "^1.6.0"


### PR DESCRIPTION
Allow users to set ads options when using the demo page.

**Checklist**

- [x] My PR title is written for customers, in line with the "Definitions" section in our git guidelines (not applicable to internal changes, chores etc).
- [x] I updated the documentation according to my changes (when applicable).
- [x] This PR is either non-breaking or [marked as breaking](https://www.conventionalcommits.org/en/v1.0.0/#examples).
