### PR TITLE
feat: Fairplay: handle assets with multiple encryption keys

### DIFF
--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Red Bee Media Ltd <https://www.redbeemedia.com/>
+
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/RELEASE_NOTES.md.license
+++ b/RELEASE_NOTES.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Red Bee Media Ltd <https://www.redbeemedia.com/>
+
+SPDX-License-Identifier: CC-BY-SA-4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -23088,8 +23088,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.throttle": "^4.1.1",
         "platform": "^1.3.6",
-        "shaka-player": "4.6.5",
-        "url-toolkit": "^2.2.5"
+        "shaka-player": "4.6.5"
       },
       "devDependencies": {
         "@types/can-autoplay": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,8 +37,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.throttle": "^4.1.1",
     "platform": "^1.3.6",
-    "shaka-player": "4.6.5",
-    "url-toolkit": "^2.2.5"
+    "shaka-player": "4.6.5"
   },
   "browserslist": [
     "safari >= 8",

--- a/packages/core/src/engines/Native.ts
+++ b/packages/core/src/engines/Native.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 import { DrmUrls } from "@ericssonbroadcastservices/rbm-ott-sdk";
-import { parseURL } from "url-toolkit";
 
 import {
   ErrorTypes,
@@ -252,7 +251,9 @@ export class Native extends AbstractBaseEngine {
 
   private async getLicense(event: MediaKeyMessageEvent) {
     this.emit(EngineEvents.DRM_UPDATE, "FAIRPLAY_LICENSE_REQUEST");
-    const licenseUrl = this.drmInfo ? new URL(this.drmInfo.licenseServerUrl) : undefined;
+    const licenseUrl = this.drmInfo
+      ? new URL(this.drmInfo.licenseServerUrl)
+      : undefined;
 
     if (!licenseUrl) {
       return Promise.reject(
@@ -363,18 +364,30 @@ export class Native extends AbstractBaseEngine {
     }
     try {
       // initData contains [4 byte: Length][EXT-X-KEY URI]
-      const dv = new DataView(event.initData.buffer, event.initData.byteOffset, event.initData.byteLength);
-      const initDataLength = dv.getUint32(0, true)
+      const dv = new DataView(
+        event.initData.buffer,
+        event.initData.byteOffset,
+        event.initData.byteLength
+      );
+      const initDataLength = dv.getUint32(0, true);
       const xKeyUrl = arrayToString(dv.buffer.slice(4, 4 + initDataLength));
       const skdUrl = new URL(xKeyUrl);
 
       if (skdUrl.protocol !== "skd:") {
-        throw new Error("Invalid Fairplay key URL in HLS manifest (skd:// scheme expected): " + xKeyUrl);
+        throw new Error(
+          `Invalid Fairplay key URL in HLS manifest (skd:// scheme expected): ${xKeyUrl}`
+        );
       }
 
       const licenseServerUrl = new URL(this.drmInfo.licenseServerUrl);
-      this.contentId = skdUrl.searchParams.get("contentId") || licenseServerUrl.searchParams.get("contentId") || skdUrl.hostname;
-      const keyId = skdUrl.searchParams.get("KID") || skdUrl.searchParams.get("keyId") || stringToUUID(skdUrl.hostname);
+      this.contentId =
+        skdUrl.searchParams.get("contentId") ||
+        licenseServerUrl.searchParams.get("contentId") ||
+        skdUrl.hostname;
+      const keyId =
+        skdUrl.searchParams.get("KID") ||
+        skdUrl.searchParams.get("keyId") ||
+        stringToUUID(skdUrl.hostname);
 
       const contentId = this.contentId;
       if (!contentId || !this.certificate) {
@@ -407,11 +420,13 @@ export class Native extends AbstractBaseEngine {
         false
       );
     } catch (err) {
-      this.emit(EngineEvents.ERROR, 
+      this.emit(
+        EngineEvents.ERROR,
         new PlayerError("[Native] could not initiate drm", {
-        type: ErrorTypes.DRM,
-        rawError: err,
-      }));
+          type: ErrorTypes.DRM,
+          rawError: err,
+        })
+      );
     }
   }
 

--- a/packages/core/src/engines/Native.ts
+++ b/packages/core/src/engines/Native.ts
@@ -13,6 +13,7 @@ import {
   arrayToString,
   getLabel,
   stringToArray,
+  stringToUUID,
 } from "@ericssonbroadcastservices/js-player-shared";
 
 import { InstanceSettingsInterface } from "../utils/interfaces";
@@ -41,6 +42,10 @@ function createTextTrack(track: IHTMLMediaAudioTrack | TextTrack): Track {
     kind: track.kind,
     label: track.label,
   };
+}
+
+interface WebKitMediaKeyNeededEvent extends Event {
+  readonly initData: Uint8Array;
 }
 
 export class Native extends AbstractBaseEngine {
@@ -247,7 +252,7 @@ export class Native extends AbstractBaseEngine {
 
   private async getLicense(event: MediaKeyMessageEvent) {
     this.emit(EngineEvents.DRM_UPDATE, "FAIRPLAY_LICENSE_REQUEST");
-    const licenseUrl = this.drmInfo?.licenseServerUrl;
+    const licenseUrl = this.drmInfo ? new URL(this.drmInfo.licenseServerUrl) : undefined;
 
     if (!licenseUrl) {
       return Promise.reject(
@@ -268,6 +273,10 @@ export class Native extends AbstractBaseEngine {
         );
       }
 
+      // session is of type WebKitMediaKeySession extended with contentId and keyId properties
+      if ("keyId" in session && typeof session.keyId === "string") {
+        licenseUrl.searchParams.set("keyId", session.keyId);
+      }
       const response = await fetch(licenseUrl, {
         method: "POST",
         headers: {
@@ -348,59 +357,62 @@ export class Native extends AbstractBaseEngine {
     return this.videoElement.webkitKeys.createSession("video/mp4", initData);
   }
 
-  private onNeedKey(event: MediaEncryptedEvent) {
+  private onNeedKey(event: WebKitMediaKeyNeededEvent) {
     if (!this.drmInfo?.licenseServerUrl) {
       return;
     }
-    const skd = arrayToString(event.initData);
-    if (skd.includes("KID=")) {
-      this.contentId = skd.substring(skd.indexOf("KID=") + 4);
-    }
-    // looking for dot as some kind of url detection
-    if (skd.includes("skd://") && skd.includes(".") && !skd.startsWith(".")) {
-      const dataArray = skd.split("skd://"); // since there could sometimes be strange encoded chars before skd we won't just do replace
-      // proper url check
-      if (parseURL(dataArray[1])) {
-        this.drmInfo.licenseServerUrl = `https://${dataArray[1]}`;
-        const dataUrl = new URL(this.drmInfo.licenseServerUrl);
-        const { contentId } = Object.fromEntries(
-          dataUrl.searchParams.entries()
-        );
+    try {
+      // initData contains [4 byte: Length][EXT-X-KEY URI]
+      const dv = new DataView(event.initData.buffer, event.initData.byteOffset, event.initData.byteLength);
+      const initDataLength = dv.getUint32(0, true)
+      const xKeyUrl = arrayToString(dv.buffer.slice(4, 4 + initDataLength));
+      const skdUrl = new URL(xKeyUrl);
 
-        // if we get relevant data, replace the data that we already have
-        this.contentId = contentId || this.contentId;
+      if (skdUrl.protocol !== "skd:") {
+        throw new Error("Invalid Fairplay key URL in HLS manifest (skd:// scheme expected): " + xKeyUrl);
       }
-      // if not fetched by the if statement - move on as it might be a proper skd
+
+      const licenseServerUrl = new URL(this.drmInfo.licenseServerUrl);
+      this.contentId = skdUrl.searchParams.get("contentId") || licenseServerUrl.searchParams.get("contentId") || skdUrl.hostname;
+      const keyId = skdUrl.searchParams.get("KID") || skdUrl.searchParams.get("keyId") || stringToUUID(skdUrl.hostname);
+
+      const contentId = this.contentId;
+      if (!contentId || !this.certificate) {
+        throw "Could not create initData, contentId & certificate missing";
+      }
+      const initData = this.concatInitDataIdAndCertificate(
+        event.initData as Uint8Array, // TODO: the legacy EME being used uses different types for certain things.
+        contentId,
+        this.certificate
+      );
+      this.keySession = this.setupSession(KeySystem.FAIRPLAY, initData);
+      this.keySession.contentId = contentId;
+      this.keySession.keyId = keyId;
+      if (!this.keySession) {
+        throw "Could not create key session";
+      }
+      this.keySession.addEventListener(
+        "webkitkeyadded",
+        this.onKeyAdded,
+        this.keySession
+      );
+      this.keySession.addEventListener(
+        "webkitkeyerror",
+        this.onKeyError,
+        this.keySession
+      );
+      this.keySession.addEventListener(
+        "webkitkeymessage",
+        this.onKeyMessage,
+        false
+      );
+    } catch (err) {
+      this.emit(EngineEvents.ERROR, 
+        new PlayerError("[Native] could not initiate drm", {
+        type: ErrorTypes.DRM,
+        rawError: err,
+      }));
     }
-    const contentId = this.contentId;
-    if (!contentId || !this.certificate) {
-      throw "Could not create initData, contentId & certificate missing";
-    }
-    const initData = this.concatInitDataIdAndCertificate(
-      event.initData as Uint8Array, // TODO: the legacy EME being used uses different types for certain things.
-      contentId,
-      this.certificate
-    );
-    this.keySession = this.setupSession(KeySystem.FAIRPLAY, initData);
-    this.keySession.contentId = contentId;
-    if (!this.keySession) {
-      throw "Could not create key session";
-    }
-    this.keySession.addEventListener(
-      "webkitkeyadded",
-      this.onKeyAdded,
-      this.keySession
-    );
-    this.keySession.addEventListener(
-      "webkitkeyerror",
-      this.onKeyError,
-      this.keySession
-    );
-    this.keySession.addEventListener(
-      "webkitkeymessage",
-      this.onKeyMessage,
-      false
-    );
   }
 
   private onKeyMessage(event: MediaKeyMessageEvent) {

--- a/packages/shared/src/helperMethods.ts
+++ b/packages/shared/src/helperMethods.ts
@@ -37,11 +37,16 @@ export const arrayToString = (array: ArrayBuffer): string => {
 
 export const stringToUUID = (input: string): string => {
   if (input.length == 32) {
-    return input.slice(0, 8) + '-' + input.slice(8, 12) + '-' + input.slice(12, 16) + '-' + input.slice(16, 20) + '-' + input.slice(20);
+    const p1 = input.slice(0, 8);
+    const p2 = input.slice(8, 12);
+    const p3 = input.slice(12, 16);
+    const p4 = input.slice(16, 20);
+    const p5 = input.slice(20);
+    return `${p1}-${p2}-${p3}-${p4}-${p5}`;
   }
   // Assuming we already have a UUID string
   return input;
-}
+};
 
 export const base64DecodeUint8Array = (input: any) => {
   const raw = window.atob(input);

--- a/packages/shared/src/helperMethods.ts
+++ b/packages/shared/src/helperMethods.ts
@@ -30,10 +30,18 @@ export const stringToArray = (string: string) => {
   return array;
 };
 
-export const arrayToString = (array: any): string => {
-  const uint16array = new Uint16Array(array.buffer);
+export const arrayToString = (array: ArrayBuffer): string => {
+  const uint16array = new Uint16Array(array);
   return String.fromCharCode.apply(null, uint16array as any);
 };
+
+export const stringToUUID = (input: string): string => {
+  if (input.length == 32) {
+    return input.slice(0, 8) + '-' + input.slice(8, 12) + '-' + input.slice(12, 16) + '-' + input.slice(16, 20) + '-' + input.slice(20);
+  }
+  // Assuming we already have a UUID string
+  return input;
+}
 
 export const base64DecodeUint8Array = (input: any) => {
   const raw = window.atob(input);

--- a/packages/shared/src/helperMethods.ts
+++ b/packages/shared/src/helperMethods.ts
@@ -42,7 +42,7 @@ export const stringToUUID = (input: string): string => {
     const p3 = input.slice(12, 16);
     const p4 = input.slice(16, 20);
     const p5 = input.slice(20);
-    return `${p1}-${p2}-${p3}-${p4}-${p5}`;
+    return [p1, p2, p3, p4, p5].join("-");
   }
   // Assuming we already have a UUID string
   return input;


### PR DESCRIPTION
Content owners mandate the use of separate encryption keys for SD and HD (or UHD) video tracks, so that different encryption policies can be enforced (eg. HDCP level).
This PR allows that by extracting the KeyID value from the skd:// URL and passing that as a query parameter in the license request.