### PR TITLE
fix: prevent safari from setting subtitles by default

### DIFF
--- a/packages/core/src/engines/AbstractBaseEngine.ts
+++ b/packages/core/src/engines/AbstractBaseEngine.ts
@@ -19,6 +19,7 @@ import {
   getLabel,
 } from "@ericssonbroadcastservices/js-player-shared";
 
+import { isAppleSafari } from "../device/common";
 import {
   ContractRestrictionsGuardian,
   IClientRestrictions,
@@ -190,6 +191,7 @@ export abstract class AbstractBaseEngine extends EmitterBaseClass<EngineEventsMa
     this.addNativeVideoEvents();
     this.addSubtitleEvents();
     this.addAudioTrackEvents();
+    this.suppressAutoSubtitles();
 
     this.on(EngineEvents.ERROR, this.onEngineEventError.bind(this));
   }
@@ -397,6 +399,21 @@ export abstract class AbstractBaseEngine extends EmitterBaseClass<EngineEventsMa
         (this.onAudioTrackChangeReference = this.onAudioTrackChange.bind(this))
       );
     }
+  }
+
+  suppressAutoSubtitles() {
+    if (!isAppleSafari()) return;
+    this.videoElement.addEventListener("play", () => {
+      const textTracks: TextTrack[] = this.videoElement.textTracks
+        ? Array.from(this.videoElement.textTracks)
+        : [];
+
+      for (const track of textTracks) {
+        if (track.mode === "showing") {
+          track.mode = "disabled";
+        }
+      }
+    });
   }
 
   isPlaying() {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Red Bee Media Ltd <https://www.redbeemedia.com/>

SPDX-License-Identifier: CC-BY-SA-4.0
-->

<!--

Please explain the changes in this PR so that any reviewer(s) understand the context.

Include JIRA issue numbers if applicable

See our git guidelines: https://github.com/EricssonBroadcastServices/team-players/blob/master/git.md
-->

**Checklist**

- [ ] My PR title is written for customers, in line with the "Definitions" section in our git guidelines (not applicable to internal changes, chores etc).
- [ ] I updated the documentation according to my changes (when applicable).
- [ ] This PR is either non-breaking or [marked as breaking](https://www.conventionalcommits.org/en/v1.0.0/#examples).
